### PR TITLE
Make open manifesto content public domain

### DIFF
--- a/license.md
+++ b/license.md
@@ -2,4 +2,24 @@
 title: License
 ---
 
-Choose a license from [Creative Commons](https://creativecommons.org) and edit it in here.
+The content of the Renew Open Manifesto is has been put into the public domain, using the CC0 1.0 Universal Public Domain Dedication.  See the [Creative Commons CC0 page](http://creativecommons.org/publicdomain/zero/1.0/) for more details.
+
+<div class="well" style='max-width: 500px; margin-left: auto; margin-right: auto; text-align: center'>
+  
+  <p xmlns:dct="http://purl.org/dc/terms/" xmlns:vcard="http://www.w3.org/2001/vcard-rdf/3.0#">
+    <a rel="license" href="http://creativecommons.org/publicdomain/zero/1.0/"><img src="https://licensebuttons.net/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" /></a>
+  </p>
+  <p>
+    To the extent possible under law,
+    <a rel="dct:publisher"
+       href="https://www.renewparty.org.uk/">
+      <span property="dct:title">Renew</span></a>
+    has waived all copyright and related or neighboring rights to
+    <span property="dct:title">The Renew Open Manifesto</span>.
+  This work is published from the
+  <span property="vcard:Country" datatype="dct:ISO3166"
+        content="GB" about="http://openpolitics.org.uk/manifesto">
+    United Kingdom</span>.
+  </p>
+
+</div>


### PR DESCRIPTION
The current content is from the OpenPolitics Manifesto, which is in the public domain. While Renew could assert a different license here (there's no restriction on reuse to the public domain), I'd suggest that putting policy ideas in the public domain where they can be freely reused and adopted by others is a good choice if the aim is to have the best chance at wider impact.